### PR TITLE
Add metadata so that README is rendered on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     author_email=AUTHOR_EMAIL,
     description=DESCRIPTION,
     long_description=LONG_DESC,
+    long_description_content_type="text/markdown",
     url=URL,
     keywords=KEYWORDS,
     license='MIT',


### PR DESCRIPTION
This will enable PyPI to render the README correctly. (ref https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi)