### PR TITLE
Add format function

### DIFF
--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -128,11 +128,13 @@ def starts_with(pattern, inp):
     pattern = dynamic_cast(T_STRING, pattern).value
     return inp.startswith(pattern)
 
+
 @register("ends_with", "endswith")
 @typed(T_STRING, T_BOOL)
 def ends_with(pattern, inp):
     pattern = dynamic_cast(T_STRING, pattern).value
     return inp.endswith(pattern)
+
 
 @register("split")
 @typed(T_STRING, T_ARRAY)
@@ -383,7 +385,7 @@ def less_equals(i, inp):
 def format(format_string, inp):
     try:
         return format_string.value.format(inp)
-    except:
-        panic('Incorrect format string {} for input {}.'.format(
+    except ValueError:
+        panic("Incorrect format string '{}' for input '{}'.".format(
             format_string.value, inp)
         )

--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -381,22 +381,9 @@ def less_equals(i, inp):
 @register("format")
 @typed(None, T_STRING)
 def format(format_string, inp):
-    format_string = format_string.value
-    is_float = format_string.endswith('f}')
-    is_integer = format_string.endswith('d}')
-    if is_float:
-        try:
-            inp = float(inp)
-        except ValueError:
-            pass
-    elif is_integer:
-        try:
-            inp = int(inp)
-        except ValueError:
-            pass
     try:
         return format_string.format(inp)
     except:
         panic('Incorrect format string {} for input {}.'.format(
-            format_string, inp)
+            format_string.value, inp)
         )

--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -382,7 +382,7 @@ def less_equals(i, inp):
 @typed(None, T_STRING)
 def format(format_string, inp):
     try:
-        return format_string.format(inp)
+        return format_string.value.format(inp)
     except:
         panic('Incorrect format string {} for input {}.'.format(
             format_string.value, inp)

--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -376,3 +376,14 @@ def less_than(i, inp):
 def less_equals(i, inp):
     i = dynamic_cast(T_INT, i).value
     return inp <= i
+
+
+@register("format")
+@typed(None, T_STRING)
+def format(format_string, inp):
+    try:
+        return (format_string.value).format(float(inp))
+    except:
+        panic("Incorrect format string {} for input {}".format(
+            format_string.value, inp)
+        )

--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -381,9 +381,22 @@ def less_equals(i, inp):
 @register("format")
 @typed(None, T_STRING)
 def format(format_string, inp):
+    format_string = format_string.value
+    is_float = format_string.endswith('f}')
+    is_integer = format_string.endswith('d}')
+    if is_float:
+        try:
+            inp = float(inp)
+        except ValueError:
+            pass
+    elif is_integer:
+        try:
+            inp = int(inp)
+        except ValueError:
+            pass
     try:
-        return (format_string.value).format(float(inp))
+        return format_string.format(inp)
     except:
-        panic("Incorrect format string {} for input {}".format(
-            format_string.value, inp)
+        panic('Incorrect format string {} for input {}.'.format(
+            format_string, inp)
         )

--- a/ft/tests/test_map.py
+++ b/ft/tests/test_map.py
@@ -31,3 +31,15 @@ def test_map_split_ext():
     map_test = mock_command(Map)
     map_test.set_input("split_ext", [], ["file.txt", "dir/image.jpg"])
     map_test.assert_output(["file\ttxt", "dir/image\tjpg"])
+
+
+def test_map_format_string():
+    map_test = mock_command(Map)
+    map_test.set_input("format", ["{:>5}"], ["abc", "b"])
+    map_test.assert_output(["  abc", "    b"])
+
+
+def test_map_format_int():
+    map_test = mock_command(Map)
+    map_test.set_input("format", ["{:02x}"], ["3", "11", "255"])
+    map_test.assert_output(["03", "0b", "ff"])


### PR DESCRIPTION
Added function to use format string, as discussed in #7.
Now the example works:

```bash
echo 3.1415 | map format "{:.2f}"
3.14
```
What do you think of this? Really not sure if `try-except` is the way to go. Unsure about typing and error checking here. For now, added type `None` for the input, since we don't want to force anything here?