### PR TITLE
Add reverse function for manipulating strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ less_than i         :: Int    → Bool
 ```
 #### String operations ####
 ```
+reverse             :: String → String
 append suffix       :: String → String
 strip               :: String → String
 substr start end    :: String → String
@@ -294,6 +295,7 @@ at idx              :: Array  → String
 index idx           :: Array  → String
 join separator      :: Array  → String
 split separator     :: String → Array
+reverse             :: Array  → Array
 ```
 #### Other operations ####
 ```

--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -402,3 +402,25 @@ def format(format_str, inp):
         panic("Incorrect format string '{}' for input '{}'.".format(
             format_str.value, inp)
         )
+
+
+@register("reverse")
+@typed(None, None)
+def reverse(inp):
+    # slice arrays and string from start to finish in reversed order
+    if type(inp) == str or type(inp) == list:
+        return inp[::-1]
+
+    # treat integers as strings
+    elif type(inp) == int:
+        return str(inp)[::-1]
+
+    # booleans can not be reversed
+    elif type(inp) == bool:
+        panic("Cannot reverse bool value")
+
+    # we got something unexpected
+    else:
+        panic("Unexpected type '{}' for input '{}'."
+              .format(type(inp).__name__, inp)
+              )


### PR DESCRIPTION
This pull request adds a function `reverse` for manipulating strings that reverse a string.

Here's an example:
```
> cat text-reverse.txt
123
456
789
```

and with `reverse`:
```
> cat test-reverse.txt | map reverse
321
654
987
```

The name comes from Python's bultin method [`reversed()`](https://docs.python.org/3/library/functions.html#reversed), that reverses a sequence.