### PR TITLE
Add filter: is_exec, testing if path is executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ basename            :: Path   → Path
 is_dir              :: Path   → Bool
 is_file             :: Path   → Bool
 is_link             :: Path   → Bool
+is_executable       :: Path   → Bool
 exists              :: Path   → Bool
 has_ext ext         :: Path   → Bool
 strip_ext           :: Path   → String

--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -335,6 +335,12 @@ def is_link(inp):
     return os.path.islink(inp)
 
 
+@register("is_executable")
+@typed(T_PATH, T_BOOL)
+def is_executable(inp):
+    return os.path.isfile(inp) and os.access(inp, os.X_OK)
+
+
 @register("contains")
 @typed(T_STRING, T_BOOL)
 def contains(substring, inp):


### PR DESCRIPTION
Example:
`ls | filter is_exec | xargs -I % ls -l %`