### PR TITLE
 Allow run to accept a string with embedded options/parameters, add quiet run

### DIFF
--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import subprocess
+from sys import stderr
 
 from ft.types import T_STRING, T_ARRAY, T_BOOL, T_PATH, T_INT, T_VOID, TypeConversionError, \
     dynamic_cast
@@ -303,13 +304,19 @@ def duplicate(inp):
 @register("run")
 @typed(T_ARRAY, T_VOID)
 def run(command, inp):
-    command = dynamic_cast(T_STRING, command).value
+    command = dynamic_cast(T_STRING, command).value.split()
     args = map(T_STRING.create_from, inp)
     args = list(map(lambda v: v.value, args))
+    print("Running '{}' with arguments {}".format(command, args), file=stderr)
+    subprocess.call(command + args)
 
-    print("Running '{}' with arguments {}".format(command, args))
-    subprocess.call([command] + args)
-
+@register("runq")
+@typed(T_ARRAY, T_VOID)
+def runq(command, inp):
+    command = dynamic_cast(T_STRING, command).value.split()
+    args = map(T_STRING.create_from, inp)
+    args = list(map(lambda v: v.value, args))
+    subprocess.call(command + args)
 
 @register("exists")
 @typed(T_PATH, T_BOOL)


### PR DESCRIPTION
This PR updates the ```run``` function to split the command on whitespace before running ```subprocess.call```, so it can have have options/parameters specified, e.g.:

```  ls | map run 'du -hsc' ```

it also adds a variant of the ```run``` function, ```runq```, which doesn't print anything about what it's doing (because I'm too lazy to parse it out of the command output)