### PR TITLE
Fix Python 3.11 error

### DIFF
--- a/ft/ft/functions.py
+++ b/ft/ft/functions.py
@@ -60,7 +60,7 @@ def typed(type_in, type_out):
 
         fn_typecheck.type_in = type_in
         fn_typecheck.type_out = type_out
-        fn_typecheck.inner_argspec = inspect.getargspec(fn)
+        fn_typecheck.inner_argspec = inspect.getfullargspec(fn)
 
         return fn_typecheck
 


### PR DESCRIPTION
The package is currently broken on Python 3.11+

[`inspect.getargspec()` was deprecated since Python 3.0, in favour of `inspect.getfullargspec()`](https://docs.python.org/3.10/library/inspect.html?highlight=inspect#inspect.getargspec); and in Python 3.11 it got finally removed.